### PR TITLE
Re-emit close events

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 module.exports = function(obj){
   var onData
     , onEnd
@@ -14,10 +13,16 @@ module.exports = function(obj){
     events.push(['end', data, encoding]);
   });
 
+  // buffer close
+  obj.on('close', onClose = function(d){
+    events.push(['close']);
+  });
+
   return {
     end: function(){
       obj.removeListener('data', onData);
       obj.removeListener('end', onEnd);
+      obj.removeListener('close', onClose);
     },
     resume: function(){
       this.end();


### PR DESCRIPTION
Rationale:

In express controllers, one often binds actions to request events. I assume that purpose of pausing streams is to attach middlewares in a way that is not affecting controllers.

However there, if close is emmited in the window, if I bind to req.on 'close' in controller, event is lost in the same way data/end is. I am using it in my proxy to note 'request happened, but was interrupted', which I may lose in the pause()d window.
