### PR TITLE
Adding repository section to package.json to suppress warning from NPM.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Pause streams...",
   "keywords": [],
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/visionmedia/node-pause.git"
+  },
   "dependencies": {},
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
NPM emits a warning when the repository field is not defined in the `package.json` file:

```
npm WARN package.json pause@0.0.1 No repository field.
```

This pull request adds the repository field. :-)
